### PR TITLE
triggering updates to make sure ScrollDown hook runs on all new messages

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -236,3 +236,7 @@ header {
 .chat-container {
   width: 100%;
 }
+
+.hidden {
+  display: none;
+}

--- a/lib/dh_sms_web/live/page_live.html.leex
+++ b/lib/dh_sms_web/live/page_live.html.leex
@@ -21,7 +21,8 @@
     </ul>
   </article>
   <article class="column column-67 current-conversation">
-    <h3 phx-hook="CurrentChat"><%= @current_conversation.contact_name %></h3>
+    <p phx-hook="CurrentChat" class="hidden"><%=length(@current_conversation.messages) %></p>
+    <h3 ><%= @current_conversation.contact_name %></h3>
     <ul >
       <%= for message <- messages_reverse_order(@current_conversation) do %>
         <li class="row">


### PR DESCRIPTION
This solution may cause problems with live view being able to efficiently send
the diff... but it works. We could fix the efficiency problem by not using
`length` and instead storing that as a property on the conversation.